### PR TITLE
bug in substratction

### DIFF
--- a/data-sets-zowe-server-package/src/main/resources/scripts/files-api-validate.sh
+++ b/data-sets-zowe-server-package/src/main/resources/scripts/files-api-validate.sh
@@ -44,4 +44,4 @@ fi
 
 . ${ROOT_DIR}/scripts/utils/validate-java.sh
 
-return $ERRORS_FOUND-$INITIAL_ERRORS_FOUND
+return $(($ERRORS_FOUND-$INITIAL_ERRORS_FOUND))


### PR DESCRIPTION
```
/root/zowe/1.7.0/components/files-api/bin/validate.sh: line 47: return: 0-0: numeric argument required
```
Signed-off-by: Vitek Vlcek <vitezslavvit.vlcek@broadcom.com>