### PR TITLE
enabled gzip compression to dataset by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,6 +137,7 @@ EOF"""
 -Dserver.ssl.keyStore=localhost.keystore.p12 \
 -Dserver.ssl.keyStorePassword=password \
 -Dserver.ssl.keyStoreType=PKCS12 \
+-Dserver.compression.enabled=true \
 -Dzosmf.httpsPort=${params.INTEGRATION_TEST_ZOSMF_PORT} \
 -Dzosmf.ipAddress=${params.INTEGRATION_TEST_ZOSMF_HOST} \
 -jar \$(ls -1 data-sets-api-server/build/libs/data-sets-api-server-*-boot.jar) &"""

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
     -Dserver.ssl.keyStore=localhost.keystore.p12 \
     -Dserver.ssl.keyStorePassword=password \
     -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dserver.compression.enabled=true \
     -Dzosmf.httpsPort=${ZOSMF_PORT} \
     -Dzosmf.ipAddress=${ZOSMF_HOST} \
     -jar $(ls -1 data-sets-api-server/build/libs/data-sets-api-server-*-boot.jar) &

--- a/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
+++ b/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
@@ -9,10 +9,12 @@
  */
 package org.zowe.spring;
 
-import java.util.Collections;
+
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
 
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -27,8 +29,8 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-        		.select()
-        		.apis(RequestHandlerSelectors.any())
+                .select()
+                .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.regex("/api.*"))
                 .build()
                 .apiInfo(

--- a/data-sets-api-server/src/main/resources/application.yaml
+++ b/data-sets-api-server/src/main/resources/application.yaml
@@ -35,6 +35,9 @@ server:
     keyAlias: ${server.ssl.keyAlias}
     enabled-protocols: TLSv1.2
     ciphers: ${apiml.security.ssl.ciphers}
+  compression:
+    enabled: ${server.compression.enabled}
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css  
     
 zosmf:
   ipAddress: ${zosmf.ipAddress}

--- a/data-sets-zowe-server-package/src/main/resources/scripts/files-api-start.sh
+++ b/data-sets-zowe-server-package/src/main/resources/scripts/files-api-start.sh
@@ -28,6 +28,7 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${COMPONENT_CODE} java -Xms16m -Xmx512m -Dibm.servers
     -Dserver.ssl.keyStore=${KEYSTORE} \
     -Dserver.ssl.keyStorePassword=${KEYSTORE_PASSWORD} \
     -Dserver.ssl.keyStoreType=PKCS12 \
+    -Dserver.compression.enabled=true \
     -Dzosmf.httpsPort=${ZOSMF_PORT} \
     -Dzosmf.ipAddress=${ZOSMF_HOST} \
     -Dspring.main.banner-mode=off \


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

Address issue https://github.com/zowe/data-sets/issues/112 , after this we support gzip compression by default, if you want to try this feature in your current installation, you can follow these steps:

1) Produce Jar locally - `data-sets-api-server\build\libs`
```
git clone git@github.com:zowe/data-sets.git
git checkout spring-gzip-compression-2
./gradlew bootJar
```
2) sftp jar produced in step 1 to replace componenets/files-api/data-sets-api-server-0.2.7.jar in your zowe installation folder
3) add `-Dserver.compression.enabled=true \` in start.sh in same folder
4) and restart zowe. 


This PR also needs https://github.com/zowe/api-layer/pull/463 
