### PR TITLE
Added ibm crypto provider that supports JCERACFKS

### DIFF
--- a/data-sets-zowe-server-package/src/main/resources/scripts/files-api-start.sh
+++ b/data-sets-zowe-server-package/src/main/resources/scripts/files-api-start.sh
@@ -35,4 +35,5 @@ _BPX_JOBNAME=${ZOWE_PREFIX}${COMPONENT_CODE} java -Xms16m -Xmx512m -Dibm.servers
     -Dconnection.httpsPort=${GATEWAY_PORT} \
     -Dconnection.ipAddress=${ZOWE_EXPLORER_HOST} \
     -Dspring.main.banner-mode=off \
+    -Djava.protocol.handler.pkgs=com.ibm.crypto.provider \
     -jar {{jar_path}} &


### PR DESCRIPTION
I've added the com.ibm.crypto.provider package via a java property so that it can work with JCERACFKS (saf keyring) keystore type.

Signed-off-by: Vit Tomica <vit.tomica@broadcom.com>