### PR TITLE
Fix swagger doc

### DIFF
--- a/data-sets-api-server/src/main/java/org/zowe/data/sets/controller/AbstractDataSetsController.java
+++ b/data-sets-api-server/src/main/java/org/zowe/data/sets/controller/AbstractDataSetsController.java
@@ -69,7 +69,7 @@ public abstract class AbstractDataSetsController {
         return new ResponseEntity<>(content.getContent(), headers, HttpStatus.OK);
     }
 
-    @PostMapping(consumes = "application/json")
+    @PostMapping(value = "/", consumes = "application/json")
     @ApiOperation(value = "Create a data set", notes = "This creates a data set based on the attributes passed in")
     @ApiResponses({@ApiResponse(code = 201, message = "Data set successfully created")})
     @ResponseStatus(HttpStatus.CREATED)

--- a/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
+++ b/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
@@ -35,7 +35,7 @@ public class SwaggerConfig {
                 .paths(PathSelectors.regex("/api.*"))
                 .build()
                 .apiInfo(
-                        new ApiInfo("Files API", "REST API for the Data sets and z/OS Unix Files Services", "1.0", null, null, null, null, Collections.emptyList())
+                        new ApiInfo("Files API", "REST API for the Data sets and z/OS Unix Files Services", "2.0", null, null, null, null, Collections.emptyList())
                 );
     }
 

--- a/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
+++ b/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
@@ -12,7 +12,9 @@ package org.zowe.spring;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+
+import java.util.Collections;
+
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
@@ -20,13 +22,10 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.Collections;
-
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
     @Bean
-    @Primary
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
                 .groupName("all")

--- a/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
+++ b/data-sets-api-server/src/main/java/org/zowe/spring/SwaggerConfig.java
@@ -10,12 +10,9 @@
 package org.zowe.spring;
 
 
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.Collections;
-
+import org.springframework.context.annotation.Primary;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
@@ -23,18 +20,74 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.util.Collections;
+
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
     @Bean
+    @Primary
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("all")
                 .select()
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.regex("/api.*"))
                 .build()
                 .apiInfo(
-                    new ApiInfo("Files API", "REST API for the Data sets and z/OS Unix Files Services", "1.0", null, null, null, null, Collections.emptyList())
+                        new ApiInfo("Files API", "REST API for the Data sets and z/OS Unix Files Services", "1.0", null, null, null, null, Collections.emptyList())
+                );
+    }
+
+    @Bean
+    public Docket apiV1Datasets() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("apiV1Datasets")
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.regex("/api/v1/datasets.*"))
+                .build()
+                .apiInfo(
+                        new ApiInfo("Datasets API", "REST API for the Data sets Service", "1.0", null, null, null, null, Collections.emptyList())
+                );
+    }
+
+    @Bean
+    public Docket apiV2Datasets() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("apiV2Datasets")
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.regex("/api/v2/datasets.*"))
+                .build()
+                .apiInfo(
+                        new ApiInfo("Datasets API", "REST API for the Data sets Service", "2.0", null, null, null, null, Collections.emptyList())
+                );
+    }
+
+    @Bean
+    public Docket apiV1UnixFiles() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("apiV1UnixFiles")
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.regex("/api/v1/unixfiles.*"))
+                .build()
+                .apiInfo(
+                        new ApiInfo("Unix Files API", "REST API for the z/OS Unix Files Service", "1.0", null, null, null, null, Collections.emptyList())
+                );
+    }
+
+    @Bean
+    public Docket apiV2UnixFiles() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("apiV2UnixFiles")
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.regex("/api/v2/unixfiles/.*"))
+                .build()
+                .apiInfo(
+                        new ApiInfo("Unix Files API", "REST API for the z/OS Unix Files Service", "2.0", null, null, null, null, Collections.emptyList())
                 );
     }
 }

--- a/data-sets-api-server/src/main/java/org/zowe/unix/files/controller/AbstractUnixFilesController.java
+++ b/data-sets-api-server/src/main/java/org/zowe/unix/files/controller/AbstractUnixFilesController.java
@@ -48,7 +48,7 @@ public abstract class AbstractUnixFilesController {
         return baseURIForLinkTo;
     }
 
-    @GetMapping(value = "", produces = {"application/json"})
+    @GetMapping(value = "/", produces = {"application/json"})
     @ApiOperation(value = "Get a list of a directories contents", nickname = "getDirectoryListing", notes = "This API gets a list of files and directories for a given path")
     @ApiResponses({@ApiResponse(code = 200, message = "Ok", response = UnixDirectoryAttributesWithChildren.class)})
     public UnixDirectoryAttributesWithChildren getUnixDirectoryListing(

--- a/data-sets-api-server/src/test/java/org/zowe/data/sets/controller/DataSetsControllerTest.java
+++ b/data-sets-api-server/src/test/java/org/zowe/data/sets/controller/DataSetsControllerTest.java
@@ -430,7 +430,7 @@ public class DataSetsControllerTest extends ApiControllerTest {
         mockDataSetUriConstruction(dataSetName, locationUri);
 
         mockMvc
-                .perform(post(ENDPOINT_ROOT).contentType(MediaType.APPLICATION_JSON_VALUE)
+                .perform(post(ENDPOINT_ROOT + "/").contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(JsonUtils.convertToJsonString(request)))
                 .andExpect(status().isCreated()).andExpect(header().string("Location", locationUri.toString()));
 

--- a/data-sets-api-server/src/test/java/org/zowe/unix/files/controller/UnixFilesControllerTest.java
+++ b/data-sets-api-server/src/test/java/org/zowe/unix/files/controller/UnixFilesControllerTest.java
@@ -54,8 +54,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @PrepareForTest({ ServletUriComponentsBuilder.class })
 public class UnixFilesControllerTest extends ApiControllerTest {
 
-    private static final String ENDPOINT_ROOT = "/api/v1/unixfiles";
-    private static final String URI_BASE = "http://localhost/api/v1/unixfiles";
+    private static final String ENDPOINT_ROOT = "/api/v1/unixfiles/";
+    private static final String URI_BASE = "http://localhost/api/v1/unixfiles/";
 
     @Mock
     private UnixFilesService unixFilesService;
@@ -408,8 +408,8 @@ public class UnixFilesControllerTest extends ApiControllerTest {
 
 
     @Test
-    public void post_unix_file_succss() throws Exception {
-        String path = "/u/newFile";
+    public void post_unix_file_success() throws Exception {
+        String path = "u/newFile";
         String permissions = "rwxrwxrwx";
         UnixCreateAssetRequest createRequest = new UnixCreateAssetRequest(UnixEntityType.FILE, permissions);
 
@@ -419,7 +419,7 @@ public class UnixFilesControllerTest extends ApiControllerTest {
             .andExpect(status().isCreated())
             .andExpect(header().string("Location", "http://localhost" + ENDPOINT_ROOT + path));
 
-        verify(unixFilesService, times(1)).createUnixAsset(path, createRequest);
+        verify(unixFilesService, times(1)).createUnixAsset("/" + path, createRequest);
         verifyNoMoreInteractions(unixFilesService);
     }
 

--- a/data-sets-zowe-server-package/src/main/resources/apiml-static-registration.yaml.template
+++ b/data-sets-zowe-server-package/src/main/resources/apiml-static-registration.yaml.template
@@ -15,13 +15,13 @@ services:
       - apiId: org.zowe.data.sets
         gatewayUrl: api/v1
         version: 1.0.0
-        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs
-        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html
+        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs?group=apiV1Datasets
+        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html?urls.primaryName=apiV1Datasets
       - apiId: org.zowe.data.sets
         gatewayUrl: api/v2
         version: 2.0.0
-        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs
-        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html
+        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs?group=apiV1Datasets
+        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html?urls.primaryName=apiV2Datasets
     customMetadata:
       apiml:
         enableUrlEncodedCharacters: true
@@ -41,13 +41,13 @@ services:
       - apiId: org.zowe.unix.files
         gatewayUrl: api/v1
         version: 1.0.0
-        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs
-        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html
+        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs?group=apiV1UnixFiles
+        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html?urls.primaryName=apiV1UnixFiles
       - apiId: org.zowe.unix.files
         gatewayUrl: api/v2
         version: 2.0.0
-        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs
-        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html
+        swaggerUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/v2/api-docs?group=apiV2UnixFiles
+        documentationUrl: https://${ZWE_haInstance_hostname:-localhost}:${ZWE_components_files_api_port}/swagger-ui.html?urls.primaryName=apiV2UnixFiles
 catalogUiTiles:
   datasetsAndUnixFiles:
     title: z/OS Datasets and Unix Files services


### PR DESCRIPTION
Previously, the swagger document for the Unix Files and Datasets API services was one large doc, with APIs v1 and v2, as well as Unix Files and Datasets APIs all contained in the one doc. Now, that one doc is still available, but there are also 4 split up docs available for v1 and v2 versions of Unix Files and Datasets, separately. This makes the view in the API Catalog much more clear, as only the APIs for the correct version and API service are displayed. This also fixes an issue where the API Catalog only transforms the swagger routes to Gateway formatted routes for the selected API service, so while on the Unix Files tab, the Datasets API routes would be malformed, leading to users thinking the route is unavailable.

<img width="1312" alt="Screen Shot 2022-05-16 at 10 52 16 AM" src="https://user-images.githubusercontent.com/14897740/168621593-51c4bd0d-7271-4fa5-802f-5cf9a0cb96bd.png">
