### PR TITLE
explictly updating the snakeYaml version as latest versions of org.springdoc:springdoc-openapi-ui and spring-boot-starter-actuator pulls <1.31 versions of snakeYAML

### DIFF
--- a/data-sets-api-server/build.gradle
+++ b/data-sets-api-server/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compile libraries.guava
     compile libraries.logback_classic
     compile libraries.logback_core
+    compile libraries.snakeyaml
     compile libraries.spring_doc
     compile libraries.tomcat_annotations_api
     compile libraries.tomcat_embed_core

--- a/data-sets-model/build.gradle
+++ b/data-sets-model/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compile libraries.gson
     compile libraries.logback_classic
     compile libraries.logback_core
+    compile libraries.snakeyaml
     compile libraries.spring_doc
     compile libraries.tomcat_annotations_api
     compile libraries.tomcat_embed_core

--- a/data-sets-tests/build.gradle
+++ b/data-sets-tests/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile libraries.http_client
     compile libraries.commons_codec
     compile libraries.gson
+	compile libraries.snakeyaml
 	compile libraries.tomcat_annotations_api
 	compile libraries.tomcat_embed_core
 	compile libraries.tomcat_embed_websocket

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,6 +14,7 @@ ext {
     httpClientVersion = '4.5.13'
     httpCoreVersion = '4.4.10'
     commonsCodecVersion = '1.15'
+    snakeYaml = "1.31"
     slf4jVersion = "1.7.25"
     jacksonCoreVersion = '2.13.2'
     jacksonDatabindVersion = '2.13.2.2'
@@ -30,6 +31,7 @@ ext {
         mapstruct_processor                : "org.mapstruct:mapstruct-processor:${mapStructVersion}",
         slf4j_simple                       : "org.slf4j:slf4j-simple:${slf4jVersion}",
         slf4j_api                          : "org.slf4j:slf4j-api:${slf4jVersion}",
+        snakeyaml                          : "org.yaml:snakeyaml:${snakeYaml}",
         spring_boot_gradle_plugin          : "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}",
         spring_boot_starter_actuator       : "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}",
         spring_boot_starter_parent         : "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}",


### PR DESCRIPTION
explictly updating the snakeYaml version as latest versions of org.springdoc:springdoc-openapi-ui and spring-boot-starter-actuator pulls <1.31 versions of snakeYAML
Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>