### PR TITLE
Replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -25,6 +25,6 @@ runs:
       shell: bash
       run: |
         version=$(cat gradle.properties | awk '/version=/' | awk -F= '{print$2;}')
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     - uses: zowe-actions/shared-actions/prepare-workflow@main


### PR DESCRIPTION
Addresses a deprecation by Github, see issue https://github.com/zowe/zowe-install-packaging/issues/3378 .