### PR TITLE
upgraded springboot to 2.7.12 and snakeyaml to 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ group 'org.zowe.explorer.files'
 
 buildscript {
     ext {
-        licenseGradlePluginVerion = '0.14.0'
+        licenseGradlePluginVersion = '0.13.1'
     }
 
     ext.mavenRepositories = {
@@ -31,7 +31,7 @@ buildscript {
     dependencies {
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7'
         classpath 'net.researchgate:gradle-release:2.6.0'
-        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVerion}"
+        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVersion}"
         classpath 'org.owasp:dependency-check-gradle:3.3.4'
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
     }

--- a/data-sets-api-server/build.gradle
+++ b/data-sets-api-server/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories mavenRepositories
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersionForGradle}")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     }
 }
 
@@ -65,6 +65,6 @@ jar {
 }
 
 bootJar {
-    mainClassName = 'org.zowe.DataSetsAndUnixFilesApplication'
-    classifier = 'boot'
+    mainClass = 'org.zowe.DataSetsAndUnixFilesApplication'
+    archiveClassifier = 'boot'
 }

--- a/data-sets-api-server/build.gradle
+++ b/data-sets-api-server/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     compile libraries.jackson_core
     compile libraries.jackson_databind
     compile libraries.gson
-    compile libraries.guava
     compile libraries.logback_classic
     compile libraries.logback_core
     compile libraries.snakeyaml

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,11 +4,10 @@ ext {
     springSecurityVersion = '5.7.8!!'
     springFrameworkVersion = '5.3.27!!'
     springDocVersion = '1.6.9'
-    lombokVersion = '1.18.26'
+    lombokVersion = '1.18.20'
     mockitoCoreVersion = '2.23.4'
     powerMockVersion = "2.0.0-RC.1"
     gsonVersion = '2.9.0'
-    guavaVersion = '31.0.1-jre'
     logbackVersion = '1.2.9'
     httpClientVersion = '4.5.13'
     httpCoreVersion = '4.4.14'
@@ -76,7 +75,6 @@ ext {
         power_mock_junit4_rule             : "org.powermock:powermock-module-junit4-rule:${powerMockVersion}",
 
         gson                               : "com.google.code.gson:gson:${gsonVersion}",
-        guava                              : "com.google.guava:guava:${guavaVersion}",
         mockito_core                       : "org.mockito:mockito-core:${mockitoCoreVersion}",
 
         junit                              : "junit:junit:${junitVersion}",

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,11 +1,10 @@
 ext {
 //TODO MARK - shouldn't this inherit from parent?
-    springBootVersion = '2.5.14'
-    springBootVersionForGradle = '2.3.12.RELEASE'
+    springBootVersion = '2.7.12'
     springSecurityVersion = '5.7.8!!'
     springFrameworkVersion = '5.3.27!!'
     springDocVersion = '1.6.9'
-    lombokVersion = '1.18.20'
+    lombokVersion = '1.18.26'
     mockitoCoreVersion = '2.23.4'
     powerMockVersion = "2.0.0-RC.1"
     gsonVersion = '2.9.0'
@@ -14,7 +13,7 @@ ext {
     httpClientVersion = '4.5.13'
     httpCoreVersion = '4.4.14'
     commonsCodecVersion = '1.15'
-    snakeYaml = "1.33"
+    snakeYaml = "2.0"
     slf4jVersion = "1.7.25"
     jacksonCoreVersion = '2.14.1'
     jacksonDatabindVersion = '2.14.1'


### PR DESCRIPTION
In order to resolve snakeyaml dependency upgrade to 2.0, springboot needs to be upgraded to 2.7.12, which prevents the use of deprecated values `mainClassName` and `classifier` in bootJar. Changing `licenseGradlePluginVersion` to 0.13.1 (same as jobs repo) also prevents errors when running job `Publish branch binaries / publish (push)`. Removed unused guava dependency.


Resolves:
https://github.com/zowe/security-reports/issues/353
https://github.com/zowe/security-reports/issues/350