### PR TITLE
upgrade guava to 32.0.1-jre and snakeyaml to 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ group 'org.zowe.explorer.files'
 
 buildscript {
     ext {
-        licenseGradlePluginVerion = '0.14.0'
+        licenseGradlePluginVersion = '0.14.0'
     }
 
     ext.mavenRepositories = {
@@ -31,7 +31,7 @@ buildscript {
     dependencies {
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7'
         classpath 'net.researchgate:gradle-release:2.6.0'
-        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVerion}"
+        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:${licenseGradlePluginVersion}"
         classpath 'org.owasp:dependency-check-gradle:3.3.4'
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ group 'org.zowe.explorer.files'
 
 buildscript {
     ext {
-        licenseGradlePluginVersion = '0.14.0'
+        licenseGradlePluginVersion = '0.13.1'
     }
 
     ext.mavenRepositories = {

--- a/data-sets-api-server/build.gradle
+++ b/data-sets-api-server/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories mavenRepositories
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersionForGradle}")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     }
 }
 
@@ -67,6 +67,6 @@ jar {
 }
 
 bootJar {
-    mainClassName = 'org.zowe.DataSetsAndUnixFilesApplication'
-    classifier = 'boot'
+    mainClass = 'org.zowe.DataSetsAndUnixFilesApplication'
+    archiveClassifier = 'boot'
 }

--- a/data-sets-tests/build.gradle
+++ b/data-sets-tests/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	compile libraries.spring_core
 	compile libraries.spring_expression
 	compile libraries.spring_web
+	compile libraries.spring_webmvc
+	compile libraries.spring_test
 	implementation(libraries.spring_boot_starter_web){
 		exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-el"
 	}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,7 +15,7 @@ ext {
     httpCoreVersion = '4.4.10'
     commonsCodecVersion = '1.15'
     slf4jVersion = "1.7.25"
-    snakeYaml = "2.0"
+    snakeYaml = "1.33"
     jacksonCoreVersion = '2.13.2'
     jacksonDatabindVersion = '2.14.0'
     jsonPathVersion = "2.4.0"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
 //TODO MARK - shouldn't this inherit from parent?
-    springBootVersion = '2.5.13'
+    springBootVersion = '2.7.12'
     springBootVersionForGradle = '2.3.12.RELEASE'
     springSecurityVersion = '5.7.8!!'
     springFrameworkVersion = '5.3.20!!'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,7 +15,7 @@ ext {
     httpCoreVersion = '4.4.10'
     commonsCodecVersion = '1.15'
     slf4jVersion = "1.7.25"
-    snakeYaml = "1.33"
+    snakeYaml = "2.0"
     jacksonCoreVersion = '2.13.2'
     jacksonDatabindVersion = '2.14.0'
     jsonPathVersion = "2.4.0"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,13 +9,13 @@ ext {
     mockitoCoreVersion = '2.23.4'
     powerMockVersion = "2.0.0-RC.1"
     gsonVersion = '2.9.0'
-    guavaVersion = '31.0.1-jre'
+    guavaVersion = '32.0.1-jre'
     logbackVersion = '1.2.9'
     httpClientVersion = '4.5.13'
     httpCoreVersion = '4.4.10'
     commonsCodecVersion = '1.15'
     slf4jVersion = "1.7.25"
-    snakeYaml = "1.33"
+    snakeYaml = "2.0"
     jacksonCoreVersion = '2.13.2'
     jacksonDatabindVersion = '2.14.0'
     jsonPathVersion = "2.4.0"


### PR DESCRIPTION
Need to upgrade Guava to v32.0.1 as v32.0.0 breaks some functionality under Windows:

https://nvd.nist.gov/vuln/detail/CVE-2023-2976

Changing licenseGradlePluginVersion to 0.13.1 (same as jobs repo) also prevents errors when running job Publish branch binaries / publish (push).