### PR TITLE
fix: server.ssl.procotol setting bug

### DIFF
--- a/data-sets-zowe-server-package/src/main/resources/bin/start.sh
+++ b/data-sets-zowe-server-package/src/main/resources/bin/start.sh
@@ -77,8 +77,7 @@ get_enabled_protocol() {
     fi
 }
 
-get_enabled_protocol_limit "server" "max"
-server_protocol=${enabled_protocol_limit:-"TLS"}
+server_protocol="TLS"
 get_enabled_protocol "server"
 server_enabled_protocols=${result:-"TLSv1.2"}
 server_ciphers=${ZWE_configs_zowe_network_server_tls_ciphers:-${ZWE_components_files_api_zowe_network_server_tls_ciphers:-${ZWE_zowe_network_server_tls_ciphers:-TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384}}}


### PR DESCRIPTION
server.ssl.protocol should be either TLS or SSL without version, that's controlled by the other setting (enabled protocols)